### PR TITLE
fix(UI) & feat: add official data for Turkish provinces

### DIFF
--- a/Sajda.xcodeproj/project.pbxproj
+++ b/Sajda.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		CCED21862E65F9770066D0EB /* NavigationAnimation+Custom.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCED21852E65F9770066D0EB /* NavigationAnimation+Custom.swift */; };
 		CCED21882E65FE650066D0EB /* AnimationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCED21872E65FE650066D0EB /* AnimationType.swift */; };
 		CCFD21DA2E62BEEB00A80402 /* PrayerTimeCorrectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFD21D92E62BEEB00A80402 /* PrayerTimeCorrectionView.swift */; };
+		AA000001DIYANET00000001 /* DiyanetLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002DIYANET00000002 /* DiyanetLookup.swift */; };
+		AA000003DIYANET00000003 /* TurkeyPrayerTimes.json in Resources */ = {isa = PBXBuildFile; fileRef = AA000004DIYANET00000004 /* TurkeyPrayerTimes.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -129,6 +131,8 @@
 		CCED21852E65F9770066D0EB /* NavigationAnimation+Custom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationAnimation+Custom.swift"; sourceTree = "<group>"; };
 		CCED21872E65FE650066D0EB /* AnimationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationType.swift; sourceTree = "<group>"; };
 		CCFD21D92E62BEEB00A80402 /* PrayerTimeCorrectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrayerTimeCorrectionView.swift; sourceTree = "<group>"; };
+		AA000002DIYANET00000002 /* DiyanetLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiyanetLookup.swift; sourceTree = "<group>"; };
+		AA000004DIYANET00000004 /* TurkeyPrayerTimes.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TurkeyPrayerTimes.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -229,6 +233,8 @@
 				CCED21872E65FE650066D0EB /* AnimationType.swift */,
 				CC4659602E661CC400159A83 /* TextFieldStepper.swift */,
 				CC4659642E6629C000159A83 /* SajdaStepper.swift */,
+				AA000002DIYANET00000002 /* DiyanetLookup.swift */,
+				AA000004DIYANET00000004 /* TurkeyPrayerTimes.json */,
 			);
 			path = Sajda;
 			sourceTree = "<group>";
@@ -390,6 +396,7 @@
 				CC969C7F2E60857D00C8630A /* Preview Assets.xcassets in Resources */,
 				CC969C7C2E60857D00C8630A /* Assets.xcassets in Resources */,
 				CC969CA32E6085F200C8630A /* Info.plist in Resources */,
+				AA000003DIYANET00000003 /* TurkeyPrayerTimes.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -453,6 +460,7 @@
 				CCE1BA3B2E61852B003AF03C /* RootViewModifier.swift in Sources */,
 				CC786E522E6353F1007299F3 /* ManualLocationSheetView.swift in Sources */,
 				CC786E562E635ADA007299F3 /* AlertWindowManager.swift in Sources */,
+				AA000001DIYANET00000001 /* DiyanetLookup.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -623,12 +631,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Sajda/Sajda.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sajda/Preview Content\"";
-				DEVELOPMENT_TEAM = R9K95P32SA;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -652,12 +660,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Sajda/Sajda.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Sajda/Preview Content\"";
-				DEVELOPMENT_TEAM = R9K95P32SA;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Sajda/AppDelegate.swift
+++ b/Sajda/AppDelegate.swift
@@ -30,8 +30,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject, NSWindowDe
         // --- PERBAIKAN UNTUK BUG WAKE-FROM-SLEEP ---
         // Menambahkan observer untuk mendeteksi saat Mac bangun dari mode sleep.
         NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(systemDidWake), name: NSWorkspace.didWakeNotification, object: nil)
-        
-        NSApp.run()
     }
     
     // --- FUNGSI BARU UNTUK MENANGANI WAKE-FROM-SLEEP ---

--- a/Sajda/DiyanetLookup.swift
+++ b/Sajda/DiyanetLookup.swift
@@ -1,0 +1,133 @@
+// MARK: - DiyanetLookup.swift
+// Loads official Diyanet prayer times from bundled JSON for all Turkish provinces
+
+import Foundation
+
+struct DiyanetPrayerTimes: Codable {
+    let fajr: String
+    let sunrise: String
+    let dhuhr: String
+    let asr: String
+    let maghrib: String
+    let isha: String
+}
+
+class DiyanetLookup {
+    static let shared = DiyanetLookup()
+    
+    // Dictionary of province name -> (date -> prayer times)
+    private var provinceTimes: [String: [String: DiyanetPrayerTimes]] = [:]
+    
+    // All 81 Turkish provinces (uppercase, Turkish characters)
+    private let turkishProvinces: Set<String> = [
+        "ADANA", "ADIYAMAN", "AFYONKARAHISAR", "AKSARAY", "AMASYA", "ANKARA", "ANTALYA",
+        "ARDAHAN", "ARTVIN", "AYDIN", "AGRI", "BALIKESIR", "BARTIN", "BATMAN", "BAYBURT",
+        "BILECIK", "BINGOL", "BITLIS", "BOLU", "BURDUR", "BURSA", "CANAKKALE", "CANKIRI",
+        "CORUM", "DENIZLI", "DIYARBAKIR", "DUZCE", "EDIRNE", "ELAZIG", "ERZINCAN", "ERZURUM",
+        "ESKISEHIR", "GAZIANTEP", "GIRESUN", "GUMUSHANE", "HAKKARI", "HATAY", "IGDIR",
+        "ISPARTA", "ISTANBUL", "IZMIR", "KAHRAMANMARAS", "KARABUK", "KARAMAN", "KARS",
+        "KASTAMONU", "KAYSERI", "KIRIKKALE", "KIRKLARELI", "KIRSEHIR", "KILIS", "KOCAELI",
+        "KONYA", "KUTAHYA", "MALATYA", "MANISA", "MARDIN", "MERSIN", "MUGLA", "MUS",
+        "NEVSEHIR", "NIGDE", "ORDU", "OSMANIYE", "RIZE", "SAKARYA", "SAMSUN", "SIIRT",
+        "SINOP", "SIVAS", "SANLIURFA", "SIRNAK", "TEKIRDAG", "TOKAT", "TRABZON", "TUNCELI",
+        "USAK", "VAN", "YALOVA", "YOZGAT", "ZONGULDAK"
+    ]
+    
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM-dd"  // Ignore year - prayer times are same for any year
+        formatter.timeZone = TimeZone(identifier: "Europe/Istanbul")
+        return formatter
+    }()
+    
+    private init() {
+        loadTurkeyData()
+    }
+    
+    private func loadTurkeyData() {
+        guard let url = Bundle.main.url(forResource: "TurkeyPrayerTimes", withExtension: "json"),
+              let data = try? Data(contentsOf: url) else {
+            print("⚠️ DiyanetLookup: Could not load TurkeyPrayerTimes.json")
+            return
+        }
+        
+        do {
+            provinceTimes = try JSONDecoder().decode([String: [String: DiyanetPrayerTimes]].self, from: data)
+        } catch {
+            print("⚠️ DiyanetLookup: Failed to decode JSON - \(error)")
+        }
+    }
+    
+    /// Find matching province for a location name
+    private func findProvince(for locationName: String) -> String? {
+        let upperLocation = locationName.uppercased(with: Locale(identifier: "tr_TR"))
+        
+        // Direct match
+        if turkishProvinces.contains(upperLocation) {
+            return upperLocation
+        }
+        
+        // Check if location contains a province name
+        for province in turkishProvinces {
+            if upperLocation.contains(province) || province.contains(upperLocation) {
+                return province
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Returns prayer times for a Turkish province on the given date
+    func getPrayerTimes(for date: Date, locationName: String, timezone: TimeZone) -> [String: Date]? {
+        guard let province = findProvince(for: locationName),
+              let times = provinceTimes[province],
+              let dayTimes = times[dateFormatter.string(from: date)] else {
+            return nil
+        }
+        
+        // Parse time strings into Date objects
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timezone
+        let dateComponents = calendar.dateComponents([.year, .month, .day], from: date)
+        
+        func parseTime(_ timeString: String) -> Date? {
+            let parts = timeString.split(separator: ":").compactMap { Int($0) }
+            guard parts.count == 2 else { return nil }
+            var components = dateComponents
+            components.hour = parts[0]
+            components.minute = parts[1]
+            components.second = 0
+            return calendar.date(from: components)
+        }
+        
+        guard let fajr = parseTime(dayTimes.fajr),
+              let sunrise = parseTime(dayTimes.sunrise),
+              let dhuhr = parseTime(dayTimes.dhuhr),
+              let asr = parseTime(dayTimes.asr),
+              let maghrib = parseTime(dayTimes.maghrib),
+              let isha = parseTime(dayTimes.isha) else {
+            print("⚠️ DiyanetLookup: Failed to parse times")
+            return nil
+        }
+        
+        return [
+            "Fajr": fajr,
+            "Sunrise": sunrise,
+            "Dhuhr": dhuhr,
+            "Asr": asr,
+            "Maghrib": maghrib,
+            "Isha": isha
+        ]
+    }
+    
+    /// Check if a location has Diyanet data available
+    func hasData(for locationName: String) -> Bool {
+        guard let province = findProvince(for: locationName) else { return false }
+        return provinceTimes[province] != nil && !provinceTimes[province]!.isEmpty
+    }
+    
+    /// List of all supported provinces
+    var supportedProvinces: [String] {
+        Array(turkishProvinces).sorted()
+    }
+}

--- a/Sajda/DiyanetLookup.swift
+++ b/Sajda/DiyanetLookup.swift
@@ -60,7 +60,7 @@ class DiyanetLookup {
     
     /// Find matching province for a location name
     private func findProvince(for locationName: String) -> String? {
-        let upperLocation = locationName.uppercased(with: Locale(identifier: "tr_TR"))
+        let upperLocation = locationName.uppercased(with: Locale(identifier: "en_US"))
         
         // Direct match
         if turkishProvinces.contains(upperLocation) {

--- a/Sajda/MainView.swift
+++ b/Sajda/MainView.swift
@@ -98,9 +98,20 @@ struct MainView: View {
 struct PrayerListView: View {
     @EnvironmentObject var vm: PrayerTimeViewModel
     private var prayerOrder: [String] {
+        // Turkish style: shows Sunrise instead of Sunnah prayers
+        let turkishOrder = ["Fajr", "Sunrise", "Dhuhr", "Asr", "Maghrib", "Isha"]
         let defaultOrder = ["Fajr", "Dhuhr", "Asr", "Maghrib", "Isha"]
         let sunnahOrder = ["Tahajud", "Fajr", "Dhuha", "Dhuhr", "Asr", "Maghrib", "Isha"]
-        let baseOrder = vm.showSunnahPrayers ? sunnahOrder : defaultOrder
+        
+        // Use Turkish order if Sunrise is available (Diyanet method)
+        let baseOrder: [String]
+        if vm.todayTimes.keys.contains("Sunrise") {
+            baseOrder = turkishOrder
+        } else if vm.showSunnahPrayers {
+            baseOrder = sunnahOrder
+        } else {
+            baseOrder = defaultOrder
+        }
         return baseOrder.filter { vm.todayTimes.keys.contains($0) }
     }
     var body: some View {

--- a/Sajda/PrayerTimeViewModel.swift
+++ b/Sajda/PrayerTimeViewModel.swift
@@ -210,25 +210,66 @@ class PrayerTimeViewModel: NSObject, ObservableObject, CLLocationManagerDelegate
         guard let prayersToday = PrayerTimes(coordinates: Coordinates(latitude: coord.latitude, longitude: coord.longitude), date: todayInLocation, calculationParameters: params),
               let prayersTomorrow = PrayerTimes(coordinates: Coordinates(latitude: coord.latitude, longitude: coord.longitude), date: tomorrowDC, calculationParameters: params) else { return }
         
-        let correctedFajr = prayersToday.fajr.addingTimeInterval(fajrCorrection * 60)
-        let correctedDhuhr = prayersToday.dhuhr.addingTimeInterval(dhuhrCorrection * 60)
-        let correctedAsr = prayersToday.asr.addingTimeInterval(asrCorrection * 60)
-        let correctedMaghrib = prayersToday.maghrib.addingTimeInterval(maghribCorrection * 60)
-        let correctedIsha = prayersToday.isha.addingTimeInterval(ishaCorrection * 60)
+        // Check if we should use Diyanet lookup for Turkish cities
+        let isDiyanet = method.name == "Diyanet (Turkey)"
+        let hasDiyanetData = DiyanetLookup.shared.hasData(for: locationStatusText)
         
-        var allPrayerTimes: [(name: String, time: Date)] = [("Fajr", correctedFajr), ("Dhuhr", correctedDhuhr), ("Asr", correctedAsr), ("Maghrib", correctedMaghrib), ("Isha", correctedIsha)]
+        var allPrayerTimes: [(name: String, time: Date)]
+        var correctedFajrTomorrow: Date
         
-        if showSunnahPrayers {
-            let correctedFajrTomorrow = prayersTomorrow.fajr.addingTimeInterval(fajrCorrection * 60)
-            let nightDuration = correctedFajrTomorrow.timeIntervalSince(correctedIsha)
-            let lastThirdOfNightStart = correctedIsha.addingTimeInterval(nightDuration * (2/3.0))
-            allPrayerTimes.append(("Tahajud", lastThirdOfNightStart))
+        if isDiyanet && hasDiyanetData,
+           let diyanetTimes = DiyanetLookup.shared.getPrayerTimes(for: Date(), locationName: locationStatusText, timezone: self.locationTimeZone),
+           let diyanetTomorrowTimes = DiyanetLookup.shared.getPrayerTimes(for: tomorrowInLocation, locationName: locationStatusText, timezone: self.locationTimeZone) {
+            // Use official Diyanet lookup times for supported Turkish cities
+            // Apply user's manual corrections on top of official times
+            allPrayerTimes = [
+                ("Fajr", diyanetTimes["Fajr"]!.addingTimeInterval(fajrCorrection * 60)),
+                ("Sunrise", diyanetTimes["Sunrise"]!),
+                ("Dhuhr", diyanetTimes["Dhuhr"]!.addingTimeInterval(dhuhrCorrection * 60)),
+                ("Asr", diyanetTimes["Asr"]!.addingTimeInterval(asrCorrection * 60)),
+                ("Maghrib", diyanetTimes["Maghrib"]!.addingTimeInterval(maghribCorrection * 60)),
+                ("Isha", diyanetTimes["Isha"]!.addingTimeInterval(ishaCorrection * 60))
+            ]
+            correctedFajrTomorrow = diyanetTomorrowTimes["Fajr"]!.addingTimeInterval(fajrCorrection * 60)
+        } else if isDiyanet {
+            // Diyanet method but not Istanbul - use calculated times with Sunrise (Turkish style)
+            let correctedFajr = prayersToday.fajr.addingTimeInterval(fajrCorrection * 60)
+            let correctedDhuhr = prayersToday.dhuhr.addingTimeInterval(dhuhrCorrection * 60)
+            let correctedAsr = prayersToday.asr.addingTimeInterval(asrCorrection * 60)
+            let correctedMaghrib = prayersToday.maghrib.addingTimeInterval(maghribCorrection * 60)
+            let correctedIsha = prayersToday.isha.addingTimeInterval(ishaCorrection * 60)
             
-            let dhuhaTime = prayersToday.sunrise.addingTimeInterval(20 * 60)
-            allPrayerTimes.append(("Dhuha", dhuhaTime))
+            allPrayerTimes = [
+                ("Fajr", correctedFajr),
+                ("Sunrise", prayersToday.sunrise),
+                ("Dhuhr", correctedDhuhr),
+                ("Asr", correctedAsr),
+                ("Maghrib", correctedMaghrib),
+                ("Isha", correctedIsha)
+            ]
+            correctedFajrTomorrow = prayersTomorrow.fajr.addingTimeInterval(fajrCorrection * 60)
+        } else {
+            // Use calculated times with manual corrections
+            let correctedFajr = prayersToday.fajr.addingTimeInterval(fajrCorrection * 60)
+            let correctedDhuhr = prayersToday.dhuhr.addingTimeInterval(dhuhrCorrection * 60)
+            let correctedAsr = prayersToday.asr.addingTimeInterval(asrCorrection * 60)
+            let correctedMaghrib = prayersToday.maghrib.addingTimeInterval(maghribCorrection * 60)
+            let correctedIsha = prayersToday.isha.addingTimeInterval(ishaCorrection * 60)
+            
+            allPrayerTimes = [("Fajr", correctedFajr), ("Dhuhr", correctedDhuhr), ("Asr", correctedAsr), ("Maghrib", correctedMaghrib), ("Isha", correctedIsha)]
+            
+            if showSunnahPrayers {
+                correctedFajrTomorrow = prayersTomorrow.fajr.addingTimeInterval(fajrCorrection * 60)
+                let nightDuration = correctedFajrTomorrow.timeIntervalSince(correctedIsha)
+                let lastThirdOfNightStart = correctedIsha.addingTimeInterval(nightDuration * (2/3.0))
+                allPrayerTimes.append(("Tahajud", lastThirdOfNightStart))
+                
+                let dhuhaTime = prayersToday.sunrise.addingTimeInterval(20 * 60)
+                allPrayerTimes.append(("Dhuha", dhuhaTime))
+            }
+            
+            correctedFajrTomorrow = prayersTomorrow.fajr.addingTimeInterval(fajrCorrection * 60)
         }
-        
-        let correctedFajrTomorrow = prayersTomorrow.fajr.addingTimeInterval(fajrCorrection * 60)
         
         DispatchQueue.main.async {
             self.todayTimes = Dictionary(uniqueKeysWithValues: allPrayerTimes.map { ($0.name, $0.time) })


### PR DESCRIPTION
The AppDelegate was calling NSApp.run() inside applicationDidFinishLaunching, but main.swift already starts the run loop via NSApplicationMain(). This caused a double run loop, blocking button clicks and UI interactions. 

Previous 'Diyanet' method only approximated using angles. This PR adds official Diyanet data for all 81 Turkish provinces, fixing inaccurate calculated times for Turkey. 